### PR TITLE
Fix CLI tests and unused import

### DIFF
--- a/spotifyActionService/src/accessor/spotifyAccessor.py
+++ b/spotifyActionService/src/accessor/spotifyAccessor.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from dependency.spotifyClient import spotify_client
 from spotipy import Spotify
 from util.logger import logger
 

--- a/spotifyActionService/tst/service/onDemandHandlerTest.py
+++ b/spotifyActionService/tst/service/onDemandHandlerTest.py
@@ -52,6 +52,9 @@ def test_main_invokes_parse_and_handle(
         fake_init,
     )
 
+    # stub get_client to avoid real OAuth setup
+    monkeypatch.setattr(under_test.spotifyClient, "get_client", lambda: None)
+
     # run main (this will use our monkeypatched methods)
     under_test.main()
 

--- a/spotifyActionService/tst/service/schedulerHandlerTest.py
+++ b/spotifyActionService/tst/service/schedulerHandlerTest.py
@@ -60,6 +60,9 @@ def test_main_schedules_and_runs_once(monkeypatch: pytest.MonkeyPatch) -> None:
         fake_init,
     )
 
+    # stub get_client to avoid real OAuth setup
+    monkeypatch.setattr(under_test.spotifyClient, "get_client", lambda: None)
+
     # 1) stub external ActionProcessor.parse_action_file
     actions = [
         Action(type=None, timeBetweenActInSeconds=3),


### PR DESCRIPTION
## Summary
- remove unused `spotify_client` import in `SpotifyAccessor`
- stub `spotifyClient.get_client` in CLI-related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9656b33c832db29222626c3830c5