### PR TITLE
Fix PyPI workflow to skip existing versions

### DIFF
--- a/.github/workflows/publishPyPi.yml
+++ b/.github/workflows/publishPyPi.yml
@@ -22,3 +22,5 @@ jobs:
         run: python -m build  # creates wheel and sdist in dist/ 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true


### PR DESCRIPTION
## Summary
- only publish a new version to PyPI when it isn't already there

## Testing
- `PYTHONPATH=$PWD/spotifyActionService/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ea88dadc4832da322cbe448bead57