### PR TITLE
Add editor to site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -5,15 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spotify Action Validator</title>
   <script src="https://cdn.jsdelivr.net/pyodide/v0.30.5/full/pyodide.js"></script>
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/codemirror.min.css"
+  />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/codemirror.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/mode/javascript/javascript.min.js"></script>
   <style>
     body { font-family: sans-serif; max-width: 800px; margin: auto; padding: 2rem; }
-    textarea { width: 100%; height: 200px; font-family: monospace; }
+    #editor { height: 300px; }
     #output { white-space: pre-wrap; background: #f0f0f0; padding: 1em; }
   </style>
 </head>
 <body>
   <h1>Spotify Action Validator</h1>
-  <textarea id="editor">{ "actions": [ { "type": "YOUR_ACTION_TYPE", ... } ] }</textarea><br/>
+  <textarea id="editor">{
+  "actions": [
+    {
+      "type": "sync",
+      "source_playlist_id": "SOURCE_ID",
+      "target_playlist_id": "TARGET_ID"
+    }
+  ]
+}</textarea>
+  <br/>
   <button id="validateBtn">Validate</button>
   <h3>Result:</h3>
   <div id="output">—</div>
@@ -31,8 +46,14 @@ await micropip.install("./spotify_action_validator-0.1-py3-none-any_emscripten_*
 
     loadEverything();
 
+    const cm = CodeMirror.fromTextArea(document.getElementById("editor"), {
+      lineNumbers: true,
+      mode: { name: "javascript", json: true },
+      viewportMargin: Infinity,
+    });
+
     document.getElementById("validateBtn").onclick = async () => {
-      const inputText = document.getElementById("editor").value;
+      const inputText = cm.getValue();
       try {
         const result = await window.validate(`
 import json


### PR DESCRIPTION
## Summary
- use CodeMirror for editing `actions.json`
- install validator via Pyodide and validate editor contents

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686eabce035c832dad40d0e16a5170f8