### PR TITLE
Fix Emscripten installation in workflow

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -37,11 +37,12 @@ jobs:
       - name: Install pyodide-build & setup Emscripten
         run: |
           pip install pyodide-build
-          echo "EMSDK_VER=$(pyodide config get emscripten_version)" >> $GITHUB_ENV
+          EMSDK_VER="4.0.9"
+          echo "EMSDK_VER=$EMSDK_VER" >> "$GITHUB_ENV"
           git clone https://github.com/emscripten-core/emsdk.git
           cd emsdk
-          ./emsdk install "${EMSDK_VER}"
-          ./emsdk activate "${EMSDK_VER}"
+          ./emsdk install "$EMSDK_VER"
+          ./emsdk activate "$EMSDK_VER"
           source emsdk_env.sh
           cd ..
 


### PR DESCRIPTION
## Summary
- avoid network lookup for Emscripten version
- pin EMSDK version to 4.0.9 when deploying validator site

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68707e9a1bc4832db68e747f3860b1c0