### PR TITLE
Update lint instructions for Ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ The scheduler’s behavior is mainly driven by the `actions.json` configuration 
 Contributions are welcome! If you have an idea for improvement or found a bug, feel free to open an issue or submit a pull request. When contributing code, please keep the following in mind:
 
 * **Project Setup:** For development, install the package in editable mode as described above. It’s recommended to also install any dev dependencies (if provided, e.g. via a `requirements-dev.txt` or Poetry extras). This project uses a `justfile` for common tasks – if you have [just](https://github.com/casey/just) installed, you can run tasks like `just format` or `just test` if defined.
-* **Coding Style:** The code is linted with **Flake8** in CI. Please run `flake8` (or `just lint`) to catch styling issues before committing.
+* **Coding Style:** The code is linted with **Ruff** in CI. Please run `ruff check` (or `just lint`) to catch styling issues before committing.
 * **Testing:** Ensure that you run **pytest** and that all tests pass. If you add new features, add corresponding unit tests. The CI pipeline will run the test suite on each pull request.
 * **Commit Messages:** Follow clear and descriptive commit messages. If your PR addresses an open issue, please reference it in the description.
 * **Branching Workflow:** It’s generally recommended to create a new branch for your feature or fix (don’t commit to `master` on your fork) and then open a PR from that branch.


### PR DESCRIPTION
## Summary
- document running `ruff check` (or `just lint`) in the README
- mention that Ruff is used in CI

## Testing
- `ruff check --fix .` *(fails: Found 1 error (1 fixed, 0 remaining))*
- `pytest -q` *(fails to import spotipy/schedule)*

------
https://chatgpt.com/codex/tasks/task_e_6870a47d46d0832d9f5150494eeae38d