### PR TITLE
Improve OAuth token handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ SPOTIPY_REDIRECT_URI=<your_redirect_uri>
 
 When you run the scheduler for the first time, it will use these credentials to open a Spotify authorization page in your browser. **Log in and authorize** the application. After authorization, the app will receive an access token (and refresh token) for your account. The token will be saved locally (by default Spotipy stores it in a `.cache` file in the working directory). On subsequent runs, it will reuse the cached token so you won’t need to re-authenticate each time.
 
+If you provide a `SPOTIPY_REFRESH_TOKEN` environment variable and the `.cache` file hasn't been created yet, the client will refresh the token automatically. This allows CI pipelines or integration tests to authenticate without opening a browser.
+
 ### 2. Defining Sync Actions (actions.json)
 
 Next, tell the scheduler what you want to sync. This is done by creating an **actions JSON configuration** (by default, the app looks for a file named `actions.json`). You can start by copying the provided template from the repository (`spotifyActionService/actions.json.template`) and filling in your details. The configuration is a JSON array of action objects. Each action can specify:

--- a/spotifyActionService/src/dependency/spotifyClient.py
+++ b/spotifyActionService/src/dependency/spotifyClient.py
@@ -1,3 +1,5 @@
+import os
+
 from spotipy import Spotify
 from spotipy.oauth2 import SpotifyOAuth
 from util.env import get_environ
@@ -12,4 +14,9 @@ def get_client() -> Spotify:
         redirect_uri=get_environ("SPOTIPY_REDIRECT_URI"),
         scope=scope,
     )
+
+    refresh_token = get_environ("SPOTIPY_REFRESH_TOKEN")
+    if refresh_token and not os.path.exists(".cache"):
+        auth_manager.refresh_access_token(refresh_token)
+
     return Spotify(auth_manager=auth_manager)

--- a/spotifyActionService/tst/dependency/spotifyClientTest.py
+++ b/spotifyActionService/tst/dependency/spotifyClientTest.py
@@ -1,0 +1,37 @@
+import os
+
+import dependency.spotifyClient as under_test
+import pytest
+
+
+class DummyOAuth:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.refreshed_with: list[str] = []
+
+    def refresh_access_token(self, token: str) -> None:
+        self.refreshed_with.append(token)
+
+
+class DummySpotify:
+    def __init__(self, auth_manager: DummyOAuth) -> None:
+        self.auth_manager = auth_manager
+
+
+def test_refresh_token_used_when_cache_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    # set required env vars
+    monkeypatch.setenv("SPOTIPY_CLIENT_ID", "cid")
+    monkeypatch.setenv("SPOTIPY_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("SPOTIPY_REDIRECT_URI", "uri")
+    monkeypatch.setenv("SPOTIPY_REFRESH_TOKEN", "refresh")
+
+    dummy = DummyOAuth()
+    monkeypatch.setattr(under_test, "SpotifyOAuth", lambda **kwargs: dummy)
+    monkeypatch.setattr(under_test, "Spotify", DummySpotify)
+
+    monkeypatch.setattr(os.path, "exists", lambda path: False)
+
+    client = under_test.get_client()
+    assert client.auth_manager is dummy
+    assert dummy.refreshed_with == ["refresh"]
+
+


### PR DESCRIPTION
## Summary
- load refresh token in spotify client
- use refresh token if `.cache` doesn't exist
- test refresh token cache priming
- document refresh token usage for CI and integration tests
- handle refresh token environment variable consistently

## Testing
- `ruff check spotifyActionService/src/dependency/spotifyClient.py spotifyActionService/tst/dependency/spotifyClientTest.py --no-fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a87a62e8832d8a230b32dae8112a