### PR TITLE
Improve Spotify auth checks

### DIFF
--- a/spotifyActionService/src/dependency/spotifyClient.py
+++ b/spotifyActionService/src/dependency/spotifyClient.py
@@ -2,11 +2,18 @@ import os
 
 from spotipy import Spotify
 from spotipy.oauth2 import SpotifyOAuth
+from spotipy.exceptions import SpotifyOauthError
 from util.env import get_environ
 
 
 def get_client() -> Spotify:
-    # Spotify auth and client setup
+    """Return an authenticated :class:`Spotify` client."""
+
+    required = ["SPOTIPY_CLIENT_ID", "SPOTIPY_CLIENT_SECRET", "SPOTIPY_REDIRECT_URI"]
+    missing = [name for name in required if not get_environ(name)]
+    if missing:
+        raise EnvironmentError(f"Missing environment variables: {', '.join(missing)}")
+
     scope = "playlist-read-private playlist-modify-public playlist-modify-private"
     auth_manager = SpotifyOAuth(
         client_id=get_environ("SPOTIPY_CLIENT_ID"),
@@ -17,6 +24,11 @@ def get_client() -> Spotify:
 
     refresh_token = get_environ("SPOTIPY_REFRESH_TOKEN")
     if refresh_token and not os.path.exists(".cache"):
-        auth_manager.refresh_access_token(refresh_token)
+        try:
+            auth_manager.refresh_access_token(refresh_token)
+        except SpotifyOauthError as exc:
+            raise SpotifyOauthError(
+                f"failed to refresh token: {exc}"
+            ) from exc
 
     return Spotify(auth_manager=auth_manager)

--- a/spotifyActionService/tst/integration/liveSpotifyTest.py
+++ b/spotifyActionService/tst/integration/liveSpotifyTest.py
@@ -5,6 +5,7 @@ import os
 import pytest
 from accessor.spotifyAccessor import SpotifyAccessor
 from dependency.spotifyClient import get_client
+from spotipy.exceptions import SpotifyOauthError
 
 
 @pytest.mark.integration
@@ -20,7 +21,10 @@ def test_can_fetch_current_user() -> None:
     if not cache_exists and not has_refresh:
         pytest.fail("Spotify auth token not available")
 
-    client = get_client()
-    accessor = SpotifyAccessor(client)
+    try:
+        client = get_client()
+        accessor = SpotifyAccessor(client)
+    except (SpotifyOauthError, EnvironmentError) as exc:
+        pytest.fail(f"Spotify auth failed: {exc}")
 
     assert accessor.user_id is not None


### PR DESCRIPTION
## Summary
- detect missing Spotify environment variables and raise an error
- ensure integration test fails when Spotify credentials or refresh token are invalid

## Testing
- `PYTHONPATH=$PWD/spotifyActionService/src pytest -q`
- `PYTHONPATH=$PWD/spotifyActionService/src pytest -m integration -q` *(fails: Spotify auth token not available)*

------
https://chatgpt.com/codex/tasks/task_e_68714efa799c832dbff4c452bb10243a