### PR TITLE
Fix CI secret names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Setup Environment
         env:
           SPOTIFY_CLIENT_ID:    ${{ secrets.SPOTIFY_CLIENT_ID }}
-          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
-          SPOTIFY_REDIRECT_URI: ${{ secrets.SPOTIFY_REDIRECT_URI }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIPY_CLIENT_SECRET }}
+          SPOTIFY_REDIRECT_URI: ${{ secrets.SPOTIPY_REDIRECT_URI }}
           SPOTIPY_REFRESH_TOKEN: ${{ secrets.SPOTIPY_REFRESH_TOKEN }}
           GPG_PASSPHRASE:       ${{ secrets.GPG_PASSPHRASE }}
         run: bash scripts/setup.sh


### PR DESCRIPTION
## Summary
- fix CI workflow secrets for Spotify credentials

## Testing
- `pip install -r requirements.txt`
- `pip install spotipy schedule click`
- `PYTHONPATH=$PWD/spotifyActionService/src pytest -m "not integration"`


------
https://chatgpt.com/codex/tasks/task_e_68759d3c8eac832db5556b5aaa299a64