### PR TITLE
Fix CI to skip Spotify integration tests when no credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,5 +47,14 @@ jobs:
       - name: Run Integration Tests
         env:
           PYTHONPATH: ${{ github.workspace }}/spotifyActionService/src
+          SPOTIFY_CLIENT_ID:    ${{ secrets.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIPY_CLIENT_SECRET }}
+          SPOTIFY_REDIRECT_URI: ${{ secrets.SPOTIPY_REDIRECT_URI }}
+          SPOTIPY_REFRESH_TOKEN: ${{ secrets.SPOTIPY_REFRESH_TOKEN }}
         run: |
+          if [ -z "$SPOTIFY_CLIENT_ID" ] || [ -z "$SPOTIFY_CLIENT_SECRET" ] || \
+             [ -z "$SPOTIFY_REDIRECT_URI" ] || [ -z "$SPOTIPY_REFRESH_TOKEN" ]; then
+            echo "Spotify credentials not available; skipping integration tests."
+            exit 0
+          fi
           uv run --extra dev pytest -m integration


### PR DESCRIPTION
## Summary
- skip Spotify integration tests in CI when no credentials are present

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687727fdd620832da2cc8b28f23cffaa