### PR TITLE
Add web server for action management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,8 @@ dependencies       = [
     "python-dotenv>=1.0.0",
     "spotipy>=2.0.0",
     "schedule>=1.0.0",
-    "click>=8.0"
+    "click>=8.0",
+    "flask>=3.0"
 ]
 classifiers        = [
   "Programming Language :: Python :: 3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ Repository         = "https://github.com/JPrier/SpotifyActionScheduler"
 
 [project.scripts]
 spotify-actions = "service.cli:cli"
+spotify-actions-web = "service.web_cli:run"
 
 [build-system]
 requires           = ["setuptools>=61.0","wheel"]

--- a/spotifyActionService/src/logic/actionValidator.py
+++ b/spotifyActionService/src/logic/actionValidator.py
@@ -4,6 +4,10 @@ import sys
 from accessor.configLoader import load_json_file
 from models.actions import ACTION_MAP, ActionType
 
+# Return codes used throughout the application
+VALIDATION_SUCCESS = 0
+VALIDATION_FAILED = 1
+
 
 def validate(filepath: str) -> int:
     # 1) Load the JSON (reports parse errors)
@@ -11,7 +15,7 @@ def validate(filepath: str) -> int:
         data = load_json_file(filepath)
     except Exception as e:
         print(f"[ERROR] Unable to load JSON: {e}", file=sys.stderr)
-        return 1
+        return VALIDATION_FAILED
     
     return validate_data(data)
     
@@ -19,7 +23,7 @@ def validate_data(data: dict) -> int:
     # Ensure top-level "actions" is present and is a list
     if "actions" not in data or not isinstance(data["actions"], list):
         print("[ERROR] Top-level 'actions' key missing or not a list.", file=sys.stderr)
-        return 1
+        return VALIDATION_FAILED
 
     errors: list[str] = []
     for idx, raw in enumerate(data["actions"]):
@@ -57,10 +61,10 @@ def validate_data(data: dict) -> int:
         print("[VALIDATION FAILED]", file=sys.stderr)
         for e in errors:
             print(f"  - {e}", file=sys.stderr)
-        return 1
+        return VALIDATION_FAILED
 
     print("✅ Validation succeeded: all actions are well-formed.")
-    return 0
+    return VALIDATION_SUCCESS
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/spotifyActionService/src/service/web_cli.py
+++ b/spotifyActionService/src/service/web_cli.py
@@ -1,0 +1,15 @@
+import click
+
+from .webserver import create_app
+
+
+@click.command(help="Run the spotify actions web server")
+@click.option("--host", default="127.0.0.1", help="Host address")
+@click.option("--port", default=5000, type=int, help="Port number")
+def run(host: str, port: int) -> None:
+    app = create_app()
+    app.run(host=host, port=port)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/spotifyActionService/src/service/webserver.py
+++ b/spotifyActionService/src/service/webserver.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import os
+from http import HTTPStatus
+
+from accessor.configLoader import load_json_file
+from flask import Flask, jsonify, request
+from logic.actionValidator import (
+    VALIDATION_SUCCESS,
+    validate_data,
+)
+
+
+def create_app(actions_file: str = "spotifyActionService/actions.json") -> Flask:
+    app = Flask(__name__)
+    app.config["ACTIONS_FILE"] = actions_file
+
+    def load_actions() -> dict:
+        if os.path.exists(actions_file):
+            return load_json_file(actions_file)
+        return {"actions": []}
+
+    def save_actions(data: dict) -> None:
+        with open(actions_file, "w") as f:
+            json.dump(data, f, indent=2)
+
+    @app.get("/actions")
+    def get_actions() -> tuple[dict, int]:
+        return jsonify(load_actions()), HTTPStatus.OK
+
+    @app.post("/actions")
+    def add_action() -> tuple[dict, int]:
+        data = load_actions()
+        actions = data.setdefault("actions", [])
+        action = request.get_json(force=True)
+        actions.append(action)
+        if validate_data(data) != VALIDATION_SUCCESS:
+            return (
+                jsonify({"status": "error", "message": "validation failed"}),
+                HTTPStatus.BAD_REQUEST,
+            )
+        save_actions(data)
+        return jsonify({"status": "ok"}), HTTPStatus.CREATED
+
+    @app.put("/actions/<int:idx>")
+    def update_action(idx: int) -> tuple[dict, int]:
+        data = load_actions()
+        actions = data.setdefault("actions", [])
+        if not (0 <= idx < len(actions)):
+            return (
+                jsonify({"status": "error", "message": "index out of range"}),
+                HTTPStatus.NOT_FOUND,
+            )
+        actions[idx] = request.get_json(force=True)
+        if validate_data(data) != VALIDATION_SUCCESS:
+            return (
+                jsonify({"status": "error", "message": "validation failed"}),
+                HTTPStatus.BAD_REQUEST,
+            )
+        save_actions(data)
+        return jsonify({"status": "ok"}), HTTPStatus.OK
+
+    @app.get("/validate")
+    def validate() -> tuple[dict, int]:
+        data = load_actions()
+        code = validate_data(data)
+        return jsonify({"code": code}), HTTPStatus.OK
+
+    return app

--- a/spotifyActionService/tst/service/webCliTest.py
+++ b/spotifyActionService/tst/service/webCliTest.py
@@ -1,0 +1,18 @@
+import pytest
+import service.web_cli as under_test
+from click.testing import CliRunner
+
+
+def test_web_cli_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = CliRunner()
+    calls: list[tuple[str, int]] = []
+
+    class DummyApp:
+        def run(self, host: str, port: int) -> None:
+            calls.append((host, port))
+
+    monkeypatch.setattr(under_test, "create_app", lambda: DummyApp())
+
+    result = runner.invoke(under_test.run, ["--host", "0.0.0.0", "--port", "1234"])
+    assert result.exit_code == 0
+    assert calls == [("0.0.0.0", 1234)]

--- a/spotifyActionService/tst/service/webServerTest.py
+++ b/spotifyActionService/tst/service/webServerTest.py
@@ -1,0 +1,49 @@
+import json
+from http import HTTPStatus
+from pathlib import Path
+
+from logic.actionValidator import VALIDATION_SUCCESS
+from service.webserver import create_app
+
+
+def test_add_and_validate(tmp_path: Path) -> None:
+    actions_file = tmp_path / "actions.json"
+    app = create_app(str(actions_file))
+    client = app.test_client()
+
+    # invalid action -> validation fails
+    resp = client.post("/actions", json={"type": "bogus"})
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+    # valid add
+    resp = client.post(
+        "/actions",
+        json={
+            "type": "sync",
+            "source_playlist_id": "s",
+            "target_playlist_id": "t",
+        },
+    )
+    assert resp.status_code == HTTPStatus.CREATED
+
+    resp = client.get("/validate")
+    assert resp.json == {"code": VALIDATION_SUCCESS}
+
+    with actions_file.open() as f:
+        data = json.load(f)
+    assert data["actions"][0]["type"] == "sync"
+
+    # update with invalid data
+    resp = client.put("/actions/0", json={"type": "bogus"})
+    assert resp.status_code == HTTPStatus.BAD_REQUEST
+
+    # update with valid data
+    resp = client.put(
+        "/actions/0",
+        json={
+            "type": "archive",
+            "source_playlist_id": "s",
+            "target_playlist_id": None,
+        },
+    )
+    assert resp.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Summary
- implement Flask web server and CLI to edit action files
- expose script `spotify-actions-web`
- share validation with existing logic
- avoid magic numbers when checking validation result
- test new CLI and server endpoints
- use HTTPStatus for server responses

## Testing
- `ruff check spotifyActionService/src/service/webserver.py spotifyActionService/tst/service/webServerTest.py spotifyActionService/tst/service/webCliTest.py spotifyActionService/src/service/web_cli.py spotifyActionService/src/logic/actionValidator.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687867b17480832db585ab96918b1643