### PR TITLE
Switch to JSON Schema validation

### DIFF
--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -5,9 +5,8 @@ on:
   push:
     branches: ["master"]
     paths:
-      - 'docs/validator/**'
-      - 'spotifyActionService/src/logic/**'
       - 'site/**'
+      - 'actions.schema.json'
   workflow_dispatch:
 
 permissions:
@@ -29,33 +28,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install pyodide-build & setup Emscripten
-        run: |
-          pip install pyodide-build
-          EMSDK_VER=4.0.9
-          echo "EMSDK_VER=$EMSDK_VER" >> "$GITHUB_ENV"
-          git clone https://github.com/emscripten-core/emsdk.git
-          cd emsdk
-          ./emsdk install 4.0.9
-          ./emsdk activate 4.0.9
-          source emsdk_env.sh
-          cd ..
-
-      - name: Build Pyodide wheel
-        run: |
-          cd spotifyActionService/src/logic
-          pyodide build
-          mkdir -p ../../../docs/validator
-          cp dist/*.whl ../../../docs/validator/
-
-      - name: Copy website assets
-        run: |
-          cp -r docs/validator/* docs/validator/
+      - name: Copy schema
+        run: cp actions.schema.json site/
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
@@ -63,7 +37,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/validator
+          path: site
 
       - name: Deploy to GitHub Pages
         id: deploy

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -4,9 +4,8 @@ name: Deploy Validator Preview
 on:
   pull_request:
     paths:
-      - 'docs/validator/**'
-      - 'spotifyActionService/src/logic/**'
       - 'site/**'
+      - 'actions.schema.json'
   workflow_dispatch:
 
 permissions:
@@ -28,33 +27,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install pyodide-build & setup Emscripten
-        run: |
-          pip install pyodide-build
-          EMSDK_VER=4.0.9
-          echo "EMSDK_VER=$EMSDK_VER" >> "$GITHUB_ENV"
-          git clone https://github.com/emscripten-core/emsdk.git
-          cd emsdk
-          ./emsdk install 4.0.9
-          ./emsdk activate 4.0.9
-          source emsdk_env.sh
-          cd ..
-
-      - name: Build Pyodide wheel
-        run: |
-          cd spotifyActionService/src/logic
-          pyodide build
-          mkdir -p ../../../docs/validator
-          cp dist/*.whl ../../../docs/validator/
-
-      - name: Copy website assets
-        run: |
-          cp -r docs/validator/* docs/validator/
+      - name: Copy schema
+        run: cp actions.schema.json site/
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
@@ -62,7 +36,7 @@ jobs:
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/validator
+          path: site
 
       - name: Deploy to GitHub Pages preview
         id: deploy

--- a/actions.schema.json
+++ b/actions.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "actions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/action" }
+    }
+  },
+  "required": ["actions"],
+  "additionalProperties": false,
+  "$defs": {
+    "action": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "type": "string", "enum": ["sync", "archive"] }
+      },
+      "oneOf": [
+        { "$ref": "#/$defs/syncAction" },
+        { "$ref": "#/$defs/archiveAction" }
+      ],
+      "unevaluatedProperties": false
+    },
+    "syncAction": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "sync" },
+        "timeBetweenActInSeconds": { "type": "integer" },
+        "source_playlist_id": { "type": "string" },
+        "target_playlist_id": { "type": "string" },
+        "avoid_duplicates": { "type": "boolean", "default": true }
+      },
+      "required": ["type", "source_playlist_id", "target_playlist_id"],
+      "additionalProperties": false
+    },
+    "archiveAction": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "archive" },
+        "timeBetweenActInSeconds": { "type": "integer" },
+        "source_playlist_id": { "type": "string" },
+        "target_playlist_id": { "type": ["string", "null"] },
+        "avoid_duplicates": { "type": "boolean", "default": true },
+        "filter_by_time": { "type": "boolean", "default": true }
+      },
+      "required": ["type", "source_playlist_id"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies       = [
     "spotipy>=2.0.0",
     "schedule>=1.0.0",
     "click>=8.0",
-    "flask>=3.0"
+    "flask>=3.0",
+    "jsonschema>=4.0"
 ]
 classifiers        = [
   "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ ruff>=0.0.47
 pytest>=7.0.0
 typing-extensions>=4.0.0
 python-dotenv>=1.0.0
+jsonschema>=4.0.0

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spotify Action Validator</title>
-  <script src="https://cdn.jsdelivr.net/pyodide/v0.30.5/full/pyodide.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ajv/8.12.0/ajv7.min.js"></script>
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.15/codemirror.min.css"
@@ -34,36 +34,30 @@
   <div id="output">—</div>
 
   <script>
-    async function loadEverything() {
-      const pyodide = await loadPyodide({ indexURL: "https://cdn.jsdelivr.net/pyodide/v0.30.5/full/" });
-      await pyodide.runPythonAsync(`
-import micropip
-await micropip.install("./spotify_action_validator-0.1-py3-none-any_emscripten_*.whl")
-`);
-      window.validate = pyodide.runPython;
-      console.log("✅ Pyodide & validator package loaded");
-    }
-
-    loadEverything();
-
+    let validate;
     const cm = CodeMirror.fromTextArea(document.getElementById("editor"), {
       lineNumbers: true,
       mode: { name: "javascript", json: true },
       viewportMargin: Infinity,
     });
 
-    document.getElementById("validateBtn").onclick = async () => {
-      const inputText = cm.getValue();
-      try {
-        const result = await window.validate(`
-import json
-from actionValidator import validate_data
-data = json.loads(${JSON.stringify(inputText)})
-print(validate_data(data))
-`);
-        document.getElementById("output").innerText = result;
-      } catch (err) {
-        document.getElementById("output").innerText = err;
+    fetch("../actions.schema.json")
+      .then((r) => r.json())
+      .then((schema) => {
+        const ajv = new Ajv({ allErrors: true });
+        validate = ajv.compile(schema);
+      });
+
+    document.getElementById("validateBtn").onclick = () => {
+      const data = JSON.parse(cm.getValue());
+      const valid = validate(data);
+      if (valid) {
+        document.getElementById("output").innerText = "0";
+      } else {
+        const msgs = validate.errors.map(
+          (e) => `${e.instancePath.slice(1) || "<root>"}: ${e.message}`
+        );
+        document.getElementById("output").innerText = msgs.join("\n");
       }
     };
   </script>

--- a/spotifyActionService/src/logic/actionValidator.py
+++ b/spotifyActionService/src/logic/actionValidator.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python3
 import sys
+import json
+from pathlib import Path
 
 from accessor.configLoader import load_json_file
-from models.actions import ACTION_MAP, ActionType
+from jsonschema import Draft202012Validator
+
+SCHEMA_PATH = Path(__file__).resolve().parents[3] / "actions.schema.json"
+
+with open(SCHEMA_PATH) as f:
+    _SCHEMA = json.load(f)
+_VALIDATOR = Draft202012Validator(_SCHEMA)
 
 # Return codes used throughout the application
 VALIDATION_SUCCESS = 0
@@ -20,47 +28,22 @@ def validate(filepath: str) -> int:
     return validate_data(data)
     
 def validate_data(data: dict) -> int:
-    # Ensure top-level "actions" is present and is a list
+    """Validate the given data against the actions JSON schema."""
+
     if "actions" not in data or not isinstance(data["actions"], list):
         print("[ERROR] Top-level 'actions' key missing or not a list.", file=sys.stderr)
         return VALIDATION_FAILED
 
-    errors: list[str] = []
-    for idx, raw in enumerate(data["actions"]):
-        ctx = f"actions[{idx}]"
-        if not isinstance(raw, dict):
-            errors.append(f"{ctx}: not an object")
-            continue
-
-        # Validate the type enum
-        typ = raw.get("type")
-        if typ is None:
-            errors.append(f"{ctx}: missing 'type' field")
-            continue
-        try:
-            a_type = ActionType(typ)
-        except ValueError:
-            errors.append(f"{ctx}: unknown action type '{typ}'")
-            continue
-
-        # Find the corresponding dataclass
-        cls = ACTION_MAP.get(a_type)
-        if cls is None:
-            errors.append(f"{ctx}: no dataclass registered for type '{typ}'")
-            continue
-
-        # Try to instantiate — dataclasses will raise on missing/wrong params
-        params = {k: v for k, v in raw.items() if k != "type"}
-        try:
-            cls(type=a_type, **params)
-        except TypeError as e:
-            errors.append(f"{ctx}: invalid parameters → {e}")
-
-    # Report
+    errors = sorted(_VALIDATOR.iter_errors(data), key=lambda e: e.path)
     if errors:
         print("[VALIDATION FAILED]", file=sys.stderr)
-        for e in errors:
-            print(f"  - {e}", file=sys.stderr)
+        for err in errors:
+            path = "".join(
+                f"[{p}]" if isinstance(p, int) else f".{p}" for p in err.absolute_path
+            )
+            if path.startswith("."):
+                path = path[1:]
+            print(f"  - {path or '<root>'}: {err.message}", file=sys.stderr)
         return VALIDATION_FAILED
 
     print("✅ Validation succeeded: all actions are well-formed.")

--- a/spotifyActionService/tst/logic/actionValidatorTest.py
+++ b/spotifyActionService/tst/logic/actionValidatorTest.py
@@ -1,7 +1,6 @@
 import logic.actionValidator as under_test
 import pytest
 from _pytest.capture import CaptureFixture
-from models.actions import ACTION_MAP, ActionType
 
 
 def test_validate_json_load_error(
@@ -67,7 +66,7 @@ def test_validate_action_not_object(
     captured = capsys.readouterr()
     assert code == 1
     assert "[VALIDATION FAILED]" in captured.err
-    assert "actions[0]: not an object" in captured.err
+    assert "actions[0]: 1 is not of type 'object'" in captured.err
 
 
 def test_validate_missing_type_field(
@@ -84,7 +83,7 @@ def test_validate_missing_type_field(
     captured = capsys.readouterr()
     assert code == 1
     assert "[VALIDATION FAILED]" in captured.err
-    assert "actions[0]: missing 'type' field" in captured.err
+    assert "actions[0]: 'type' is a required property" in captured.err
 
 
 def test_validate_unknown_type(
@@ -101,38 +100,9 @@ def test_validate_unknown_type(
     captured = capsys.readouterr()
     assert code == 1
     assert "[VALIDATION FAILED]" in captured.err
-    assert "actions[0]: unknown action type 'bogus'" in captured.err
+    assert "actions[0].type: 'bogus' is not one of ['sync', 'archive']" in captured.err
 
 
-def test_validate_unregistered_type(
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: CaptureFixture,
-) -> None:
-    monkeypatch.setattr(
-        under_test,
-        "load_json_file",
-        lambda path: {
-            "actions": [
-                {
-                    "type": "sync",
-                    "source_playlist_id": "s",
-                    "target_playlist_id": "t",
-                }
-            ]
-        },
-    )
-    # remove SyncAction mapping
-    monkeypatch.setitem(
-        ACTION_MAP,
-        ActionType.SYNC,
-        None,
-    )
-
-    code = under_test.validate("dummy.json")
-    captured = capsys.readouterr()
-    assert code == 1
-    assert "[VALIDATION FAILED]" in captured.err
-    assert "actions[0]: no dataclass registered for type 'sync'" in captured.err
 
 
 def test_validate_invalid_params(
@@ -149,7 +119,7 @@ def test_validate_invalid_params(
     captured = capsys.readouterr()
     assert code == 1
     assert "[VALIDATION FAILED]" in captured.err
-    assert "actions[0]: invalid parameters" in captured.err
+    assert "actions[0]: {'type': 'sync'} is not valid under any of the given schemas" in captured.err
 
 
 def test_validate_success(


### PR DESCRIPTION
## Summary
- add `actions.schema.json` schema
- replace dataclass-based validation with jsonschema
- update browser validator to use Ajv
- adjust tests for new validation behavior
- declare jsonschema in project requirements

## Testing
- `PYTHONPATH=spotifyActionService/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a69b25690832dabc9dfe31fc17e0a