### PR TITLE
Add sync-liked CLI command and do_sync_liked handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,17 @@ Here’s an example **`actions.json`** with a couple of typical scenarios:
     "source_playlist_id": "37i9dQZF1DX8FwnYE6PRvL",
     "avoid_duplicates": true,
     "timeBetweenActInSeconds": 86400
+  },
+  {
+    "type": "sync_liked",
+    "target_playlist_id": "37i9dQZF1DX2TRYkJECvfB",
+    "timeBetweenActInSeconds": 86400,
+    "max_tracks": 500
   }
 ]
 ```
+
+The **`sync_liked`** action copies tracks from your Liked Songs into `target_playlist_id`, but only ones saved within the last `timeBetweenActInSeconds` seconds (as with `archive`, this field doubles as both the scheduler's run interval and the lookback window). `max_tracks` caps how many of your most-recently-liked tracks it will scan per run (default `500`).
 
 **How to find Spotify Playlist IDs:** You can get the playlist ID from the Spotify app or web URL. For example, in a Spotify playlist link like `https://open.spotify.com/playlist/37i9dQZF1DX2TRYkJECvfB`, the string after `/playlist/` (here `37i9dQZF1DX2TRYkJECvfB`) is the playlist ID.
 

--- a/spotifyActionService/src/dependency/spotifyClient.py
+++ b/spotifyActionService/src/dependency/spotifyClient.py
@@ -27,8 +27,6 @@ def get_client() -> Spotify:
         try:
             auth_manager.refresh_access_token(refresh_token)
         except SpotifyOauthError as exc:
-            raise SpotifyOauthError(
-                f"failed to refresh token: {exc}"
-            ) from exc
+            raise SpotifyOauthError(f"failed to refresh token: {exc}") from exc
 
     return Spotify(auth_manager=auth_manager)

--- a/spotifyActionService/src/logic/actionValidator.py
+++ b/spotifyActionService/src/logic/actionValidator.py
@@ -24,9 +24,10 @@ def validate(filepath: str) -> int:
     except Exception as e:
         print(f"[ERROR] Unable to load JSON: {e}", file=sys.stderr)
         return VALIDATION_FAILED
-    
+
     return validate_data(data)
-    
+
+
 def validate_data(data: dict) -> int:
     """Validate the given data against the actions JSON schema."""
 

--- a/spotifyActionService/src/service/cli.py
+++ b/spotifyActionService/src/service/cli.py
@@ -3,6 +3,7 @@ import click
 from .mainHandler import (
     do_archive,
     do_sync,
+    do_sync_liked,
     run_actions_once,
     start_scheduled_actions,
 )
@@ -69,6 +70,45 @@ def archive(
         days=days,
         avoid_duplicates=no_duplicates,
         filter_by_time=no_time_filter,
+    )
+
+
+@cli.command(
+    "sync-liked",
+    help="Sync tracks Liked in the last N hours into TARGET_PLAYLIST_ID",
+)
+@click.argument("target_playlist_id")
+@click.option(
+    "--hours",
+    "-h",
+    type=int,
+    default=24,
+    show_default=True,
+    help="Only sync tracks liked within this many hours",
+)
+@click.option(
+    "--no-duplicates/--allow-duplicates",
+    default=True,
+    help="Skip tracks already in the target playlist",
+)
+@click.option(
+    "--max-tracks",
+    type=int,
+    default=500,
+    show_default=True,
+    help="Maximum number of liked tracks to scan",
+)
+def sync_liked(
+    target_playlist_id: str,
+    hours: int,
+    no_duplicates: bool,
+    max_tracks: int,
+) -> None:
+    do_sync_liked(
+        target_playlist_id,
+        hours=hours,
+        avoid_duplicates=no_duplicates,
+        max_tracks=max_tracks,
     )
 
 

--- a/spotifyActionService/src/service/mainHandler.py
+++ b/spotifyActionService/src/service/mainHandler.py
@@ -3,7 +3,7 @@ import logic.playlistLogic as _pl_logic
 import service.onDemandHandler as _odh
 import service.schedulerHandler as _sch
 from accessor.spotifyAccessor import SpotifyAccessor as _SpotifyAccessor
-from models.actions import ActionType, ArchiveAction, SyncAction
+from models.actions import ActionType, ArchiveAction, SyncAction, SyncLikedAction
 
 
 def do_sync(
@@ -52,6 +52,29 @@ def do_archive(
     service.archive_playlists(action)
     tgt = target_playlist_id or "removed"
     print(f"✅ Archived from {source_playlist_id!r} → {tgt!r}")
+
+
+def do_sync_liked(
+    target_playlist_id: str,
+    hours: int = 24,
+    avoid_duplicates: bool = True,
+    max_tracks: int = 500,
+) -> None:
+    """
+    Sync tracks Liked (saved) within the last `hours` hours into a playlist.
+    """
+    client = _spotifyClient.get_client()
+    accessor = _SpotifyAccessor(client)
+    service = _pl_logic.PlaylistService(accessor)
+    action = SyncLikedAction(
+        type=ActionType.SYNC_LIKED,
+        timeBetweenActInSeconds=hours * 3600,
+        target_playlist_id=target_playlist_id,
+        avoid_duplicates=avoid_duplicates,
+        max_tracks=max_tracks,
+    )
+    service.sync_liked_tracks(action)
+    print(f"✅ Synced liked songs from last {hours}h → {target_playlist_id!r}")
 
 
 def run_actions_once() -> None:

--- a/spotifyActionService/tst/accessor/spotifyAccessorTest.py
+++ b/spotifyActionService/tst/accessor/spotifyAccessorTest.py
@@ -221,6 +221,7 @@ def test_add_tracks_to_playlist_failure(
         under_test.add_tracks_to_playlist("pFAIL", ["1"])
     assert "Failed to add tracks to playlist pFAIL: API down" in caplog.text
 
+
 def test_get_playlist_metadata_success(
     dummy_client: object,
 ) -> None:

--- a/spotifyActionService/tst/dependency/spotifyClientTest.py
+++ b/spotifyActionService/tst/dependency/spotifyClientTest.py
@@ -33,5 +33,3 @@ def test_refresh_token_used_when_cache_missing(monkeypatch: pytest.MonkeyPatch) 
     client = under_test.get_client()
     assert client.auth_manager is dummy
     assert dummy.refreshed_with == ["refresh"]
-
-

--- a/spotifyActionService/tst/logic/actionValidatorTest.py
+++ b/spotifyActionService/tst/logic/actionValidatorTest.py
@@ -106,8 +106,6 @@ def test_validate_unknown_type(
     )
 
 
-
-
 def test_validate_invalid_params(
     monkeypatch: pytest.MonkeyPatch,
     capsys: CaptureFixture,

--- a/spotifyActionService/tst/service/cliTest.py
+++ b/spotifyActionService/tst/service/cliTest.py
@@ -89,6 +89,53 @@ def test_cli_archive_custom_flags(
     assert calls == [("sID", "tID", 10, False, False)]
 
 
+def test_cli_sync_liked_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = CliRunner()
+    calls: list[tuple[str, int, bool, int]] = []
+    monkeypatch.setattr(
+        cli_module,
+        "do_sync_liked",
+        lambda tgt, hours, avoid_duplicates, max_tracks: calls.append(
+            (tgt, hours, avoid_duplicates, max_tracks)
+        ),
+    )
+
+    result = runner.invoke(cli_module.cli, ["sync-liked", "tgt789"])
+    assert result.exit_code == 0
+    assert calls == [("tgt789", 24, True, 500)]
+
+
+def test_cli_sync_liked_custom_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = CliRunner()
+    calls: list[tuple[str, int, bool, int]] = []
+    monkeypatch.setattr(
+        cli_module,
+        "do_sync_liked",
+        lambda tgt, hours, avoid_duplicates, max_tracks: calls.append(
+            (tgt, hours, avoid_duplicates, max_tracks)
+        ),
+    )
+
+    result = runner.invoke(
+        cli_module.cli,
+        [
+            "sync-liked",
+            "tgt1",
+            "--hours",
+            "12",
+            "--allow-duplicates",
+            "--max-tracks",
+            "100",
+        ],
+    )
+    assert result.exit_code == 0
+    assert calls == [("tgt1", 12, False, 100)]
+
+
 def test_cli_run_once_invokes_run_actions_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/spotifyActionService/tst/service/mainHandlerTest.py
+++ b/spotifyActionService/tst/service/mainHandlerTest.py
@@ -7,7 +7,13 @@ import service.mainHandler as under_test
 from accessor.spotifyAccessor import SpotifyAccessor
 from dependency import spotifyClient
 from logic import playlistLogic
-from models.actions import Action, ActionType, ArchiveAction, SyncAction
+from models.actions import (
+    Action,
+    ActionType,
+    ArchiveAction,
+    SyncAction,
+    SyncLikedAction,
+)
 from service import onDemandHandler, schedulerHandler
 
 
@@ -109,6 +115,41 @@ def test_do_archive(
     assert action.timeBetweenActInSeconds == 5 * 24 * 3600
     assert action.avoid_duplicates is True
     assert action.filter_by_time is False
+
+
+def test_do_sync_liked(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[Any] = []
+
+    class DummyService:
+        def __init__(self, accessor: Action) -> None:
+            calls.append(("init", accessor))
+
+        def sync_liked_tracks(self, action: Action) -> None:
+            calls.append(("sync_liked", action))
+
+    monkeypatch.setattr(
+        playlistLogic,
+        "PlaylistService",
+        DummyService,
+    )
+
+    under_test.do_sync_liked("TGT3", hours=6, avoid_duplicates=False, max_tracks=200)
+
+    out = capsys.readouterr().out.strip()
+    assert out == "✅ Synced liked songs from last 6h → 'TGT3'"
+
+    kind, action = calls[1]
+    assert kind == "sync_liked"
+
+    assert isinstance(action, SyncLikedAction)
+    assert action.type == ActionType.SYNC_LIKED
+    assert action.target_playlist_id == "TGT3"
+    assert action.timeBetweenActInSeconds == 6 * 3600
+    assert action.avoid_duplicates is False
+    assert action.max_tracks == 200
 
 
 def test_run_actions_once(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- PR #36 added the `sync_liked` action type (schema, models, accessor, playlist logic) but didn't add a CLI entry point.
- Adds `do_sync_liked()` to `mainHandler.py` and a `spotify-actions sync-liked TARGET_PLAYLIST_ID` command, matching the existing `sync`/`archive` CLI patterns (`--hours`, `--allow-duplicates`, `--max-tracks` flags).
- Adds README docs for the `sync_liked` action type in `actions.json`.

## Test plan
- [x] `PYTHONPATH=$PWD/spotifyActionService/src uv run --extra dev python -m pytest -m "not integration"` → 76 passed
- [x] `uvx ruff format .` and `uvx ruff check --exit-zero .` → clean
- [x] Validated `actions.json.template` against `actions.schema.json` via `actionValidator.py` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)