### PR TITLE
Add user-library-read scope required by sync_liked

### DIFF
--- a/spotifyActionService/src/dependency/spotifyClient.py
+++ b/spotifyActionService/src/dependency/spotifyClient.py
@@ -14,7 +14,10 @@ def get_client() -> Spotify:
     if missing:
         raise OSError(f"Missing environment variables: {', '.join(missing)}")
 
-    scope = "playlist-read-private playlist-modify-public playlist-modify-private"
+    scope = (
+        "playlist-read-private playlist-modify-public playlist-modify-private "
+        "user-library-read"
+    )
     auth_manager = SpotifyOAuth(
         client_id=get_environ("SPOTIFY_CLIENT_ID"),
         client_secret=get_environ("SPOTIFY_CLIENT_SECRET"),


### PR DESCRIPTION
## Summary
Running a `sync_liked` action (added in #36) fails with `403 Insufficient client scope` on `/me/tracks`, because `get_client()` never requests the `user-library-read` scope. This adds it.

Found while validating `sync_liked` end-to-end against the live API.

Note for existing installs: cached tokens were granted without this scope, so a one-time re-authorization is required after upgrading (delete `.cache` / clear `SPOTIPY_REFRESH_TOKEN` and re-run the auth flow).

## Test plan
- [x] Full test suite passes (73 passed)
- [x] `uvx ruff check` clean
- [x] Verified live: `run-once` with a `sync_liked` action fails 403 on master, and the same 403 points at the missing scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)